### PR TITLE
fix send button moving up with expanding message TextArea

### DIFF
--- a/resources/qml/pages/MessagingPage.qml
+++ b/resources/qml/pages/MessagingPage.qml
@@ -247,6 +247,7 @@ Page {
             id: sendButton
             enabled: true
             icon.source: getSendButtonImage()
+            anchors.bottom: parent.bottom
             width: 100
             onClicked: {
                 if (editbox.text.length === 0 && sendmsgview.attachmentPath.length === 0) {


### PR DESCRIPTION
When the message entered spans across multiple lines, the send button would move up with the top of the TextArea, eventually leaving the screen. 
This anchors the send button to the bottom of the Row element containing the TextArea and the send button.