### PR TITLE
Fix Image uploads

### DIFF
--- a/source/Shmoose.cpp
+++ b/source/Shmoose.cpp
@@ -267,6 +267,20 @@ void Shmoose::sendMessage(QString const &toJid, QString const &message, QString 
     msg->setID(msgId);
     msg->setBody(message.toStdString());
 
+    if(type == "image")
+    {
+        QString outOfBandElement("");
+        outOfBandElement.append("<x xmlns=\"jabber:x:oob\">");
+        outOfBandElement.append("<url>");
+        outOfBandElement.append(message);
+        outOfBandElement.append("</url>");
+        outOfBandElement.append("</x>");
+
+        boost::shared_ptr<Swift::RawXMLPayload> outOfBand =
+                boost::make_shared<Swift::RawXMLPayload>(outOfBandElement.toStdString());
+        msg->addPayload(outOfBand);
+    }
+
     Swift::Message::Type messagesTyp = Swift::Message::Chat;
     if (rosterController_->isGroup(toJid))
     {

--- a/source/Shmoose.cpp
+++ b/source/Shmoose.cpp
@@ -39,6 +39,8 @@ Shmoose::Shmoose(NetworkFactories* networkFactories, QObject *parent) :
     hasInetConnection_(false), netFactories_(networkFactories),
     rosterController_(new RosterController(this)),
     persistence_(new Persistence(this)),
+    discoItemReq_(NULL),
+    danceFloor_(),
     httpFileUploadManager_(new HttpFileUploadManager(this)),
     downloadManager_(new DownloadManager()),
     xmppPingController_(new XmppPingController()),
@@ -75,6 +77,8 @@ Shmoose::~Shmoose()
 
     ipHeartBeatWatcher_->stopWatching();
     ipHeartBeatWatcher_->terminate();
+
+    cleanupDiscoServiceWalker();
 
     if (connected_)
     {
@@ -176,13 +180,16 @@ void Shmoose::handleConnected()
         rosterController_->requestRosterFromClient(client_);
 
         // request the discoInfo from server
-        GetDiscoInfoRequest::ref discoInfoRequest = GetDiscoInfoRequest::create(JID(client_->getJID().getDomain()), client_->getIQRouter());
-        discoInfoRequest->onResponse.connect(boost::bind(&Shmoose::handleServerDiscoInfoResponse, this, _1, _2));
-        discoInfoRequest->send();
+        boost::shared_ptr<Swift::DiscoServiceWalker> topLevelInfo(
+                    new Swift::DiscoServiceWalker(JID(client_->getJID().getDomain()), client_->getIQRouter()));
+        topLevelInfo->onServiceFound.connect(boost::bind(&Shmoose::handleDiscoServiceWalker, this, _1, _2));
+        topLevelInfo->beginWalk();
+        danceFloor_.append(topLevelInfo);
 
-        GetDiscoItemsRequest::ref discoItemsRequest = GetDiscoItemsRequest::create(JID(client_->getJID().getDomain()), client_->getIQRouter());
-        discoItemsRequest->onResponse.connect(boost::bind(&Shmoose::handleServerDiscoItemsResponse, this, _1, _2));
-        discoItemsRequest->send();
+        // find additional items on the server
+        discoItemReq_ = GetDiscoItemsRequest::create(JID(client_->getJID().getDomain()), client_->getIQRouter());
+        discoItemReq_->onResponse.connect(boost::bind(&Shmoose::handleServerDiscoItemsResponse, this, _1, _2));
+        discoItemReq_->send();
 
         // pass the client pointer to the httpFileUploadManager
         httpFileUploadManager_->setClient(client_);
@@ -454,40 +461,50 @@ void Shmoose::handleMessageReceived(Message::ref message)
     }
 }
 
-void Shmoose::handleServerDiscoInfoResponse(boost::shared_ptr<DiscoInfo> info, ErrorPayload::ref error)
+void Shmoose::handleDiscoServiceWalker(const JID & jid, boost::shared_ptr<DiscoInfo> info)
 {
-    //qDebug() << "Shmoose::handleServerDiscoInfoResponse";
+    qDebug() << "Shmoose::handleDiscoWalkerService for '" << QString::fromStdString(jid.toString()) << "'.";
+    for(auto feature : info->getFeatures())
+    {
+        qDebug() << "Shmoose::handleDiscoWalkerService feature '" << QString::fromStdString(feature) << "'.";
+    }
     const std::string httpUpload = "urn:xmpp:http:upload";
 
-    if (!error)
+    if (info->hasFeature(httpUpload))
     {
-        qDebug() << "DiscoInfo Node '" << QString::fromStdString(info->getNode()) << "'.";
-        if (info->hasFeature(httpUpload))
-        {
-            qDebug() << "has feature urn:xmpp:http:upload";
-            //severHasFeatureHttpUpload = true;
-            httpFileUploadManager_->setSeverHasFeatureHttpUpload(true);
+        qDebug() << "has feature urn:xmpp:http:upload";
+        httpFileUploadManager_->setServerHasFeatureHttpUpload(true);
+        httpFileUploadManager_->setUploadServerJid(jid);
 
-            foreach (Swift::Form::ref form, info->getExtensions())
+        foreach (Swift::Form::ref form, info->getExtensions())
+        {
+            if (form)
             {
-                if (form)
+                if ((*form).getFormType() == httpUpload)
                 {
-                    //qDebug() << "form: " << QString::fromStdString((*form).getFormType());
-                    if ((*form).getFormType() == httpUpload)
+                    Swift::FormField::ref formField = (*form).getField("max-file-size");
+                    if (formField)
                     {
-                        Swift::FormField::ref formField = (*form).getField("max-file-size");
-                        if (formField)
-                        {
-                            unsigned int maxFileSize = std::stoi((*formField).getTextSingleValue());
-                            qDebug() << QString::fromStdString((*formField).getName()) << " val: " << maxFileSize;
-                            httpFileUploadManager_->setMaxFileSize(maxFileSize);
-                        }
+                        unsigned int maxFileSize = std::stoi((*formField).getTextSingleValue());
+                        qDebug() << QString::fromStdString((*formField).getName()) << " val: " << maxFileSize;
+                        httpFileUploadManager_->setMaxFileSize(maxFileSize);
                     }
                 }
             }
         }
     }
 }
+
+void Shmoose::cleanupDiscoServiceWalker()
+{
+    for(auto walker : danceFloor_)
+    {
+        walker->endWalk();
+    }
+
+    danceFloor_.clear();
+}
+
 
 void Shmoose::handleServerDiscoItemsResponse(boost::shared_ptr<DiscoItems> items, ErrorPayload::ref error)
 {
@@ -497,9 +514,11 @@ void Shmoose::handleServerDiscoItemsResponse(boost::shared_ptr<DiscoItems> items
         for(auto item : items->getItems())
         {
             qDebug() << "Item '" << QString::fromStdString(item.getJID().toString()) << "'.";
-            GetDiscoInfoRequest::ref discoInfoRequest = GetDiscoInfoRequest::create(item.getJID(), client_->getIQRouter());
-            discoInfoRequest->onResponse.connect(boost::bind(&Shmoose::handleServerDiscoInfoResponse, this, _1, _2));
-            discoInfoRequest->send();
+            boost::shared_ptr<Swift::DiscoServiceWalker> itemInfo(
+                        new Swift::DiscoServiceWalker(JID(client_->getJID().getDomain()), client_->getIQRouter()));
+            itemInfo->onServiceFound.connect(boost::bind(&Shmoose::handleDiscoServiceWalker, this, _1, _2));
+            itemInfo->beginWalk();
+            danceFloor_.append(itemInfo);
         }
     }
 }

--- a/source/Shmoose.h
+++ b/source/Shmoose.h
@@ -81,6 +81,7 @@ private:
 	void handleDisconnected(const boost::optional<ClientError> &error);
 	void handleMessageReceived(Swift::Message::ref message);
 	void handleServerDiscoInfoResponse(boost::shared_ptr<DiscoInfo> info, ErrorPayload::ref error);
+    void handleServerDiscoItemsResponse(boost::shared_ptr<DiscoItems> items, ErrorPayload::ref error);
 	void handleStanzaAcked(Stanza::ref stanza);
 
 	void requestHttpUploadSlot();

--- a/source/Shmoose.h
+++ b/source/Shmoose.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QStringList>
+#include <QList>
 
 #include <Swiften/Swiften.h>
 
@@ -81,7 +82,9 @@ private:
 	void handleDisconnected(const boost::optional<ClientError> &error);
 	void handleMessageReceived(Swift::Message::ref message);
 	void handleServerDiscoInfoResponse(boost::shared_ptr<DiscoInfo> info, ErrorPayload::ref error);
-    void handleServerDiscoItemsResponse(boost::shared_ptr<DiscoItems> items, ErrorPayload::ref error);
+	void handleDiscoServiceWalker(const JID & jid, boost::shared_ptr<DiscoInfo> info);
+	void cleanupDiscoServiceWalker();
+	void handleServerDiscoItemsResponse(boost::shared_ptr<DiscoItems> items, ErrorPayload::ref error);
 	void handleStanzaAcked(Stanza::ref stanza);
 
 	void requestHttpUploadSlot();
@@ -104,6 +107,9 @@ private:
 
 	RosterController* rosterController_;
 	Persistence* persistence_;
+
+	Swift::GetDiscoItemsRequest::ref discoItemReq_;
+	QList<boost::shared_ptr<Swift::DiscoServiceWalker> > danceFloor_;
 
 	HttpFileUploadManager* httpFileUploadManager_;
 	DownloadManager *downloadManager_;

--- a/source/xep/httpFileUpload/HttpFileUploadManager.cpp
+++ b/source/xep/httpFileUpload/HttpFileUploadManager.cpp
@@ -15,7 +15,7 @@
 
 HttpFileUploadManager::HttpFileUploadManager(QObject *parent) : QObject(parent),
 	httpUpload_(new HttpFileUploader(this)),
-	severHasFeatureHttpUpload_(false), maxFileSize_(0),
+    serverHasFeatureHttpUpload_(false), maxFileSize_(0),
 	file_(new QFile(this)), jid_(""), client_(NULL),
 	statusString_(""), getUrl_(""), busy_(false)
 {
@@ -35,7 +35,7 @@ bool HttpFileUploadManager::requestToUploadFileForJid(const QString &file, const
 {
 	bool returnValue = false;
 
-	if (busy_ == false && client_ != NULL && severHasFeatureHttpUpload_ == true)
+    if (busy_ == false && client_ != NULL && serverHasFeatureHttpUpload_ == true)
 	{
         QString preparedImageForSending = createTargetImageName(file);
 
@@ -66,12 +66,12 @@ QString HttpFileUploadManager::getStatus()
 
 void HttpFileUploadManager::setSeverHasFeatureHttpUpload(bool hasFeature)
 {
-	severHasFeatureHttpUpload_ = hasFeature;
+    serverHasFeatureHttpUpload_ = hasFeature;
 }
 
 bool HttpFileUploadManager::getSeverHasFeatureHttpUpload()
 {
-	return severHasFeatureHttpUpload_;
+    return serverHasFeatureHttpUpload_;
 }
 
 void HttpFileUploadManager::setMaxFileSize(unsigned int maxFileSize)

--- a/source/xep/httpFileUpload/HttpFileUploadManager.cpp
+++ b/source/xep/httpFileUpload/HttpFileUploadManager.cpp
@@ -15,9 +15,9 @@
 
 HttpFileUploadManager::HttpFileUploadManager(QObject *parent) : QObject(parent),
 	httpUpload_(new HttpFileUploader(this)),
-    serverHasFeatureHttpUpload_(false), maxFileSize_(0),
+	serverHasFeatureHttpUpload_(false), maxFileSize_(0),
 	file_(new QFile(this)), jid_(""), client_(NULL),
-	statusString_(""), getUrl_(""), busy_(false)
+	uploadServerJid_(""), statusString_(""), getUrl_(""), busy_(false)
 {
 	connect(httpUpload_, SIGNAL(updateStatus(QString)), this, SLOT(updateStatusString(QString)));
 	connect(httpUpload_, SIGNAL(uploadSuccess()), this, SLOT(successReceived()));
@@ -35,7 +35,7 @@ bool HttpFileUploadManager::requestToUploadFileForJid(const QString &file, const
 {
 	bool returnValue = false;
 
-    if (busy_ == false && client_ != NULL && serverHasFeatureHttpUpload_ == true)
+	if (busy_ == false && client_ != NULL && serverHasFeatureHttpUpload_ == true)
 	{
         QString preparedImageForSending = createTargetImageName(file);
 
@@ -64,14 +64,25 @@ QString HttpFileUploadManager::getStatus()
 	return statusString_;
 }
 
-void HttpFileUploadManager::setSeverHasFeatureHttpUpload(bool hasFeature)
+void HttpFileUploadManager::setServerHasFeatureHttpUpload(bool hasFeature)
 {
-    serverHasFeatureHttpUpload_ = hasFeature;
+	serverHasFeatureHttpUpload_ = hasFeature;
 }
 
-bool HttpFileUploadManager::getSeverHasFeatureHttpUpload()
+
+bool HttpFileUploadManager::getServerHasFeatureHttpUpload()
 {
-    return serverHasFeatureHttpUpload_;
+	return serverHasFeatureHttpUpload_;
+}
+
+void HttpFileUploadManager::setUploadServerJid(Swift::JID const & uploadServerJid)
+{
+	uploadServerJid_ = uploadServerJid;
+}
+
+Swift::JID HttpFileUploadManager::getUploadServerJid()
+{
+	return uploadServerJid_;
 }
 
 void HttpFileUploadManager::setMaxFileSize(unsigned int maxFileSize)
@@ -92,7 +103,7 @@ void HttpFileUploadManager::requestHttpUploadSlot()
 		 + std::string("<size>") + std::to_string(file_->size()) + std::string("</size></request>");
 
 	Swift::RawRequest::ref httpUploadRequest = Swift::RawRequest::create(Swift::IQ::Type::Get,
-																		 Swift::JID(client_->getJID().getDomain()),
+																		 uploadServerJid_,
 																		 uploadRequest,
 																		 client_->getIQRouter());
 	httpUploadRequest->onResponse.connect(boost::bind(&HttpFileUploadManager::handleHttpUploadResponse, this, _1));

--- a/source/xep/httpFileUpload/HttpFileUploadManager.h
+++ b/source/xep/httpFileUpload/HttpFileUploadManager.h
@@ -41,7 +41,7 @@ private:
     bool createAttachmentPath();
     QString createTargetImageName(QString source);
 
-	bool severHasFeatureHttpUpload_;
+    bool serverHasFeatureHttpUpload_;
 	unsigned int maxFileSize_;
 
 	QFile* file_;

--- a/source/xep/httpFileUpload/HttpFileUploadManager.h
+++ b/source/xep/httpFileUpload/HttpFileUploadManager.h
@@ -19,8 +19,11 @@ public:
 
 	void setClient(Swift::Client* client);
 
-	void setSeverHasFeatureHttpUpload(bool hasFeature);
-	bool getSeverHasFeatureHttpUpload();
+	void setServerHasFeatureHttpUpload(bool hasFeature);
+	bool getServerHasFeatureHttpUpload();
+
+	void setUploadServerJid(Swift::JID const & uploadServerJid);
+	Swift::JID getUploadServerJid();
 
 	void setMaxFileSize(unsigned int maxFileSize);
 	unsigned int getMaxFileSize();
@@ -41,13 +44,14 @@ private:
     bool createAttachmentPath();
     QString createTargetImageName(QString source);
 
-    bool serverHasFeatureHttpUpload_;
+	bool serverHasFeatureHttpUpload_;
 	unsigned int maxFileSize_;
 
 	QFile* file_;
 	QString jid_;
 
 	Swift::Client* client_;
+	Swift::JID uploadServerJid_;
 
 	QString statusString_;
 	QString getUrl_;


### PR DESCRIPTION
This fixes #5 
The Discovery code has been changed to look for other items on the server (often subdomains taking care of specific auxiliary parts of XMPP) and thus find the upload target if it is presented under another item.
Additionally this PR adds a `jabber:x:oob` tag, which makes Clients like Conversations show the image instead of just the URL.