### PR TITLE
Get the right build and link flags from swiften-config.

### DIFF
--- a/harbour-shmoose.pro
+++ b/harbour-shmoose.pro
@@ -7,8 +7,8 @@ contains(DEFINES, SFOS) {
 }
 
 # from swift-config
-SWIFTCXX = -DSWIFTEN_STATIC -DBOOST_ALL_NO_LIB -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_SIGNALS_NO_DEPRECATION_WARNING -DSWIFT_EXPERIMENTAL_FT
-SWIFTLIB = -lSwiften -lSwiften_Boost -lrt -lz -lssl -lcrypto -lxml2 -lresolv -lpthread -ldl -lm -lc -lstdc++
+SWIFTCXX = $$system("swiften-config --cflags")
+SWIFTLIB = $$system("swiften-config --libs")
 
 TEMPLATE = app
 QT += qml quick core sql xml concurrent


### PR DESCRIPTION
This takes advantage from the fact that with standard packaging,
swiften installs a binary, swiften-config, which should be used
for generating the flags.

If a local build is used, please make sure that swiften-config
is in your path and that its output is sane.