### PR TITLE
fix incorrect connection status when using ethernet

### DIFF
--- a/resources/qml/main.qml
+++ b/resources/qml/main.qml
@@ -196,12 +196,10 @@ ApplicationWindow {
             if (ethernet.connected)
             {
                 console.log("ethernet connected")
-                textsecure.connectEvent()
             }
             else
             {
                 console.log("ethernet DISconnected")
-                textsecure.disconnectEvent()
             }
             mainWindow.hasInetConnection = mainWindow.getHasInetConnection()
             shmoose.setHasInetConnection(mainWindow.hasInetConnection)


### PR DESCRIPTION
This fixes Shmoose incorrectly thinking it is disconnected when using ethernet as connection method (like in the emulator), because the `onConnectedChanged` handler of the ethernet TechnologyModel exits prematurely when calling non-existent methods.