### PR TITLE
update SFOS build instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,12 +81,13 @@ To cross compile for Sailfish OS, do the following
 Fetch swift source::
 
  * wget https://swift.im/downloads/releases/swift-3.0/swift-3.0.tar.gz
- * tar -xzvf swift-3.0.tar.gz
- * cd swift-3.0/
+ * mkdir swift-3.0-arm
+ * cd swift-3.0-arm
+ * tar --strip-components=1 -xzvf ../swift-3.0.tar.gz
 
 Install all dependencies to build swiften::
 
- * sb2 -t SailfishOS-armv7hl -m sdk-install -R zypper in openssl-devel libiphb-devel
+ * sb2 -t SailfishOS-armv7hl -m sdk-install -R zypper in openssl-devel libiphb-devel libxml2-devel
 
 Patch SConstruct file to do a PIC build of the library archive
 
@@ -100,7 +101,7 @@ Build Swiften Library::
 
  * sb2 -t SailfishOS-armv7hl /bin/bash ./scons Swiften
 
-Get Smooshe source code::
+Get Shmoose source code::
 
  * cd ..
  * git clone https://github.com/geobra/harbour-shmoose


### PR DESCRIPTION
Some things I noticed when setting up a new build environment.

One more thing was that building Swiften failed like this:
```
  CC 3rdParty/LibMiniUPnPc/src/miniupnpc/miniupnpc.o
3rdParty/LibMiniUPnPc/src/miniupnpc/miniupnpc.c:77:8: error: redefinition of 'struct ip_mreqn'
 struct ip_mreqn
        ^
In file included from /usr/include/netinet/in.h:37:0,
                 from 3rdParty/LibMiniUPnPc/src/miniupnpc/miniupnpc.c:55:
/usr/include/bits/in.h:119:8: note: originally defined here
 struct ip_mreqn
        ^
scons: *** [3rdParty/LibMiniUPnPc/src/miniupnpc/miniupnpc.o] Error 1
scons: building terminated because of errors.
```

I resorted to commenting out that structure defined on line 77 and following. Is there a better way?