### PR TITLE
Implements XEP-280

### DIFF
--- a/source/base/Shmoose.cpp
+++ b/source/base/Shmoose.cpp
@@ -13,6 +13,7 @@
 
 #include <Swiften/Elements/DiscoInfo.h>
 #include <Swiften/Elements/DiscoItems.h>
+#include <Swiften/Queries/Requests/EnableCarbonsRequest.h>
 
 #include <Swiften/Base/IDGenerator.h>
 
@@ -128,6 +129,9 @@ void Shmoose::mainConnect(const QString &jid, const QString &pass)
 
     // https://xmpp.org/extensions/xep-0333.html
     discoInfo.addFeature(ChatMarkers::chatMarkersIdentifier.toStdString());
+
+    // https://xmpp.org/extensions/xep-0280.html
+    discoInfo.addFeature(Swift::DiscoInfo::MessageCarbonsFeature);
 
     client_->getDiscoManager()->setDiscoInfo(discoInfo);
 

--- a/source/networkconnection/ConnectionHandler.cpp
+++ b/source/networkconnection/ConnectionHandler.cpp
@@ -63,6 +63,22 @@ void ConnectionHandler::handleConnected()
     }
 
     client_->sendPresence(Swift::Presence::create("Send me a message"));    // FIXME presence handler
+    // message carbons request must be made each time a connection is established
+    enableMessageCarbons();
+}
+
+void ConnectionHandler::enableMessageCarbons() {
+    auto enableCarbonsRequest = Swift::EnableCarbonsRequest::create(client_->getIQRouter());
+    enableCarbonsRequest->onResponse.connect(boost::bind(&ConnectionHandler::handleCarbonsReply, this, _1, _2));
+    enableCarbonsRequest->send();
+}
+
+void ConnectionHandler::handleCarbonsReply(Swift::Payload::ref, Swift::ErrorPayload::ref error){
+    if (error) {
+    	qDebug() << "Failed to enable carbons";
+    } else {
+    	qDebug() << "Successfully enabled carbons";
+    }
 }
 
 void ConnectionHandler::handleDisconnected(const boost::optional<Swift::ClientError>& error)

--- a/source/networkconnection/ConnectionHandler.h
+++ b/source/networkconnection/ConnectionHandler.h
@@ -36,6 +36,8 @@ private slots:
 private:
     void handleConnected();
     void handleDisconnected(const boost::optional<Swift::ClientError> &error);
+    void handleCarbonsReply(Swift::Payload::ref, Swift::ErrorPayload::ref error);
+    void enableMessageCarbons();
 
     bool connected_;
     bool initialConnectionSuccessfull_;


### PR DESCRIPTION
This patch implements XEP-280, message carbons.
Please double check that everything works as expected, as I could not test it on the field myself. I don't expect problems though, since the relevant code looks identical to what it was on my previous pull request.

Fixes #34

Side note: LGTM fails to build because it still uses Swiften 3