### PR TITLE
Only show attach button if supported by server

### DIFF
--- a/resources/qml/pages/MessagingPage.qml
+++ b/resources/qml/pages/MessagingPage.qml
@@ -313,7 +313,7 @@ Page {
             icon.source: getSendButtonImage()
             width: 100
             onClicked: {
-                if (editbox.text.length === 0 && sendmsgview.attachmentPath.length === 0) {
+                if (editbox.text.length === 0 && sendmsgview.attachmentPath.length === 0 && shmoose.canSendFile()) {
                     sendmsgview.attachmentPath = ""
                     fileModel.searchPath = shmoose.settings.ImagePaths
                     pageStack.push(pageImagePicker)
@@ -342,11 +342,22 @@ Page {
                 sendButton.icon.source = getSendButtonImage()
             }
         }
+        Connections {
+            target: shmoose
+            onSignalCanSendFile: {
+                console.log("HTTP uploads enabled");
+                sendButton.icon.source = getSendButtonImage();
+            }
+        }
     }
 
     function getSendButtonImage() {
         if (editbox.text.length === 0 && sendmsgview.attachmentPath.length === 0) {
-            return "image://theme/icon-m-attach"
+            if (shmoose.canSendFile()) {
+                return "image://theme/icon-m-attach"
+            } else {
+                return "image://theme/icon-m-enter-accept"
+            }
         } else {
             if (sendmsgview.attachmentPath.length > 0) {
                 return "image://theme/icon-m-media"

--- a/resources/qml/pages/MessagingPage.qml
+++ b/resources/qml/pages/MessagingPage.qml
@@ -325,7 +325,6 @@ Page {
                     if (sendmsgview.attachmentPath.length > 0) {
                         shmoose.sendFile(conversationId, sendmsgview.attachmentPath);
                         sendmsgview.attachmentPath = ""
-                        editbox.enabled = true
                     }
 
                     if (msgToSend.length > 0) {
@@ -339,8 +338,6 @@ Page {
             }
             function processAttachment(path) {
                 //console.log(path)
-                editbox.text = basename(path)
-                editbox.enabled = false // disable message edition while sending image
                 sendmsgview.attachmentPath = path
                 sendButton.icon.source = getSendButtonImage()
             }

--- a/resources/qml/pages/MessagingPage.qml
+++ b/resources/qml/pages/MessagingPage.qml
@@ -325,6 +325,7 @@ Page {
                     if (sendmsgview.attachmentPath.length > 0) {
                         shmoose.sendFile(conversationId, sendmsgview.attachmentPath);
                         sendmsgview.attachmentPath = ""
+                        editbox.enabled = true
                     }
 
                     if (msgToSend.length > 0) {
@@ -338,6 +339,8 @@ Page {
             }
             function processAttachment(path) {
                 //console.log(path)
+                editbox.text = basename(path)
+                editbox.enabled = false // disable message edition while sending image
                 sendmsgview.attachmentPath = path
                 sendButton.icon.source = getSendButtonImage()
             }

--- a/source/base/DiscoInfoHandler.cpp
+++ b/source/base/DiscoInfoHandler.cpp
@@ -56,6 +56,7 @@ void DiscoInfoHandler::handleDiscoServiceWalker(const Swift::JID & jid, std::sha
             qDebug() << QString::fromStdString(jid.toString()) << " has feature urn:xmpp:http:upload";
             httpFileUploadManager_->setServerHasFeatureHttpUpload(true);
             httpFileUploadManager_->setUploadServerJid(jid);
+            emit serverHasHttpUpload_(true);
 
             foreach (Swift::Form::ref form, info->getExtensions())
             {

--- a/source/base/DiscoInfoHandler.h
+++ b/source/base/DiscoInfoHandler.h
@@ -17,6 +17,7 @@ public:
     void setupWithClient(Swift::Client* client);
 
 signals:
+    void serverHasHttpUpload_(bool);
     void serverHasMam_(bool);
 
 public slots:

--- a/source/base/Shmoose.cpp
+++ b/source/base/Shmoose.cpp
@@ -60,6 +60,7 @@ Shmoose::Shmoose(Swift::NetworkFactories* networkFactories, QObject *parent) :
     connect(mucManager_, SIGNAL(newGroupForContactsList(QString,QString)), rosterController_, SLOT(addGroupAsContact(QString,QString)));
     connect(mucManager_, SIGNAL(removeGroupFromContactsList(QString)), rosterController_, SLOT(removeGroupFromContacts(QString)) );
 
+    connect(discoInfoHandler_, SIGNAL(serverHasHttpUpload_(bool)), this, SIGNAL(signalCanSendFile(bool)));
     connect(discoInfoHandler_, SIGNAL(serverHasMam_(bool)), mamManager_, SLOT(setServerHasFeatureMam(bool)));
     connect(mucManager_, SIGNAL(newGroupForContactsList(QString,QString)), mamManager_, SLOT(receiveRoomWithName(QString, QString)));
 
@@ -283,6 +284,11 @@ Settings* Shmoose::getSettings()
 bool Shmoose::connectionState() const
 {
     return connectionHandler_->isConnected();
+}
+
+bool Shmoose::canSendFile()
+{
+    return httpFileUploadManager_->getServerHasFeatureHttpUpload();
 }
 
 QString Shmoose::getAttachmentPath()

--- a/source/base/Shmoose.h
+++ b/source/base/Shmoose.h
@@ -48,6 +48,7 @@ public:
 
     Q_INVOKABLE QString getLocalFileForUrl(const QString& str);
 
+    Q_INVOKABLE bool canSendFile();
     Q_INVOKABLE QString getVersion();
 
     bool connectionState() const;
@@ -70,6 +71,8 @@ signals:
     void settingsChanged();
 
     void connectionStateChanged();
+
+    void signalCanSendFile(bool);
 
     void signalShowMessage(QString headline, QString body);
     void signalShowStatus(QString headline, QString body);

--- a/source/qml/SendView.qml
+++ b/source/qml/SendView.qml
@@ -87,11 +87,21 @@ Rectangle {
         Button {
             Layout.alignment: Qt.AlignVCenter
 
+            id: attachButton
             text: "attach"
+            enabled: false
 
             onClicked: {
                 console.log("attach")
                 fileDialog.open();
+            }
+        }
+
+        Connections {
+            target: shmoose
+            onSignalCanSendFile: {
+                console.log("HTTP uploads enabled");
+                attachButton.enabled = true;
             }
         }
 


### PR DESCRIPTION
Hi, one slight issue I found is that if even if http upload support is not discovered, there's still an attach button in the interface that will fail silently.

An idea would be to only enable those buttons if upload support is on, else:
- in sillica interface, show only the regular button
- in the desktop view, disable the attach button

To allow for this, first I added methods to the Shmoose class to report the capability to send files. But there is a small complication: the interface is created first and http-upload discovery can take some time to happen... So I also added a signal to go from the service discovery to update the UI when needed.

What do you think of this?

Regards