### PR TITLE
Use contact name in notification rather than jid.

### DIFF
--- a/resources/qml/main.qml
+++ b/resources/qml/main.qml
@@ -57,11 +57,12 @@ ApplicationWindow {
     }
 
     function newMessageNotification(id, jid, body) {
+        var jidName = shmoose.rosterController.getNameForJid(jid)
         var m = messageNotification.createObject(null)
         m.category = "harbour-shmoose-message"
-        m.previewSummary = jid
+        m.previewSummary = jidName
         m.previewBody = body
-        m.summary = jid
+        m.summary = jidName
         m.body = body
         m.clicked.connect(function() {
             mainWindow.activate()


### PR DESCRIPTION
Hi,

Here a little request/suggestion: notifications are titled using the jid, which can be tricky some times (I use a FBmessenger gateway where jids are only numbers for example).

Maybe the notifications could use the contact name attribute? I've seen there's a fallback in RosterItem, so it should be ok to just display RosterController getNameForJid() result (like base messages/mails notifications do) or use maybe  a "Name <jid>" string format we want to more informative?

Regards 