### PR TITLE
omemo interop with Conversations

### DIFF
--- a/source/xep/httpFileUpload/FileWithCypher.cpp
+++ b/source/xep/httpFileUpload/FileWithCypher.cpp
@@ -82,15 +82,15 @@ bool FileWithCypher::initDecryptionOnWrite(const QString &ivAndKey)
         cipherHd_ = nullptr;
     }
 
-    if(ivAndKey.count() == 88)
+    // Supports 2 modes (IV on 12 or 16 bytes) to be compatible with some versions of Conversations
+    if(ivAndKey.count() == 88 || ivAndKey.count() == 96)
     {
-        QByteArray iv(12, '\0');
-        QByteArray key(32, '\0');       
-
+        QByteArray iv;
+        QByteArray key;
         ivAndKey_ = ivAndKey; 
 
-        iv = QByteArray::fromHex(ivAndKey.mid(0, 24).toLatin1());
-        key = QByteArray::fromHex(ivAndKey.mid(24, 64).toLatin1());
+        iv = QByteArray::fromHex(ivAndKey.left(ivAndKey.count()-64).toLatin1());
+        key = QByteArray::fromHex(ivAndKey.right(64).toLatin1());
 
         ret_val = gcry_cipher_open(&cipherHd_, GCRY_CIPHER_AES256, GCRY_CIPHER_MODE_GCM, 0);
 


### PR DESCRIPTION
This is a fix to handle use cases when Conversations sends an initialization vector on 32 characters (16 bytes) instead of 24 characters (12 bytes) to decrypt a file